### PR TITLE
Create an admin monitor for warning about duplicate events from GitHub

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitor.java
+++ b/src/main/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitor.java
@@ -1,0 +1,40 @@
+package org.jenkinsci.plugins.github.admin;
+
+import hudson.Extension;
+import hudson.model.AdministrativeMonitor;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.github.Messages;
+import org.jenkinsci.plugins.github.webhook.subscriber.DuplicateEventsSubscriber;
+
+@SuppressWarnings("unused")
+@Extension
+public class GitHubDuplicateEventsMonitor extends AdministrativeMonitor {
+
+    @Override
+    public String getDisplayName() {
+        return Messages.duplicate_events_administrative_monitor_displayname();
+    }
+
+    public String getDescription() {
+        return Messages.duplicate_events_administrative_monitor_description();
+    }
+
+    public String getBlurb() {
+        return Messages.duplicate_events_administrative_monitor_blurb();
+    }
+
+    @Override
+    public boolean isActivated() {
+        return !DuplicateEventsSubscriber.getDuplicateEventCounts().isEmpty();
+    }
+
+    @Override
+    public boolean hasRequiredPermission() {
+        return Jenkins.get().hasPermission(Jenkins.SYSTEM_READ);
+    }
+
+    @Override
+    public void checkRequiredPermission() {
+        Jenkins.get().checkPermission(Jenkins.SYSTEM_READ);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/extension/GHSubscriberEvent.java
+++ b/src/main/java/org/jenkinsci/plugins/github/extension/GHSubscriberEvent.java
@@ -18,6 +18,8 @@ public class GHSubscriberEvent extends SCMEvent<String> {
      */
     private final GHEvent ghEvent;
 
+    private final String eventGuid;
+
     /**
      * Constructs a new {@link GHSubscriberEvent}.
      *
@@ -25,9 +27,28 @@ public class GHSubscriberEvent extends SCMEvent<String> {
      * @param ghEvent the type of event received from GitHub.
      * @param payload the event payload.
      */
+    @Deprecated
     public GHSubscriberEvent(@CheckForNull String origin, @NonNull GHEvent ghEvent, @NonNull String payload) {
         super(Type.UPDATED, payload, origin);
         this.ghEvent = ghEvent;
+        this.eventGuid = null;
+    }
+
+    /**
+     * Constructs a new {@link GHSubscriberEvent}.
+     * @param eventGuid the globally unique identifier (GUID) to identify the event.
+     * @param origin  the origin (see {@link SCMEvent#originOf(HttpServletRequest)}) or {@code null}.
+     * @param ghEvent the type of event received from GitHub.
+     * @param payload the event payload.
+     */
+    public GHSubscriberEvent(
+            @CheckForNull String eventGuid,
+            @CheckForNull String origin,
+            @NonNull GHEvent ghEvent,
+            @NonNull String payload) {
+        super(Type.UPDATED, payload, origin);
+        this.ghEvent = ghEvent;
+        this.eventGuid = eventGuid;
     }
 
     /**
@@ -39,4 +60,8 @@ public class GHSubscriberEvent extends SCMEvent<String> {
         return ghEvent;
     }
 
+    @CheckForNull
+    public String getEventGuid() {
+        return eventGuid;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DuplicateEventsSubscriber.java
+++ b/src/main/java/org/jenkinsci/plugins/github/webhook/subscriber/DuplicateEventsSubscriber.java
@@ -1,0 +1,100 @@
+package org.jenkinsci.plugins.github.webhook.subscriber;
+
+import static com.google.common.collect.Sets.immutableEnumSet;
+
+import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.model.PeriodicWork;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
+import org.jenkinsci.plugins.github.extension.GHSubscriberEvent;
+import org.kohsuke.github.GHEvent;
+
+@Extension
+public final class DuplicateEventsSubscriber extends GHEventsSubscriber {
+
+    private static final Logger LOGGER = Logger.getLogger(DuplicateEventsSubscriber.class.getName());
+    private static final Map<String, EventCountWithTTL> EVENT_COUNTS_TRACKER = new ConcurrentHashMap<>();
+    private static final long TTL_MILLIS = TimeUnit.MINUTES.toMillis(10);
+
+    @VisibleForTesting
+    record EventCountWithTTL(int count, long lastUpdated) { }
+
+    /**
+     * This method is retained only because it is an abstract method.
+     * It is no longer used to determine event delivery to subscribers.
+     * Instead, {@link #isInterestedIn} and {@link #events()} are now used to
+     * decide whether an event should be delivered to a subscriber.
+     * @see com.cloudbees.jenkins.GitHubWebHook#doIndex
+     */
+    @Override
+    protected boolean isApplicable(@Nullable Item item) {
+        return false;
+    }
+
+    @Override
+    protected Set<GHEvent> events() {
+        return immutableEnumSet(GHEvent.PUSH);
+    }
+
+    @Override
+    protected void onEvent(final GHSubscriberEvent event) {
+        String eventGuid = event.getEventGuid();
+        if (eventGuid == null) {
+            return;
+        }
+        long now = Instant.now().toEpochMilli();
+        EVENT_COUNTS_TRACKER.compute(
+                eventGuid, (key, value) -> new EventCountWithTTL(value == null ? 1 : value.count() + 1, now));
+        cleanUpOldEntries(now);
+    }
+
+    public static Map<String, Integer> getDuplicateEventCounts() {
+        return EVENT_COUNTS_TRACKER.entrySet().stream()
+                .filter(entry -> entry.getValue().count() > 1)
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, entry -> entry.getValue().count()));
+    }
+
+    private static void cleanUpOldEntries(long now) {
+        EVENT_COUNTS_TRACKER
+                .entrySet()
+                .removeIf(entry -> (now - entry.getValue().lastUpdated()) > TTL_MILLIS);
+    }
+
+    /**
+     * Only for testing purpose
+     */
+    @VisibleForTesting
+    static Map<String, EventCountWithTTL> getEventCountsTracker() {
+        return new ConcurrentHashMap<>(EVENT_COUNTS_TRACKER);
+    }
+
+    @SuppressWarnings("unused")
+    @Extension
+    public static class EventCountTrackerCleanup extends PeriodicWork {
+
+        @Override
+        public long getRecurrencePeriod() {
+            return TTL_MILLIS;
+        }
+
+        @Override
+        protected void doRun() {
+            LOGGER.log(
+                    Level.FINE,
+                    () -> "Cleaning up entries older than " + TTL_MILLIS + "ms, remaining entries: "
+                            + EVENT_COUNTS_TRACKER.size());
+            cleanUpOldEntries(Instant.now().toEpochMilli());
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/github/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github/Messages.properties
@@ -11,3 +11,8 @@ github.trigger.check.method.warning.details=The webhook for repo {0}/{1} on {2} 
   More info can be found on the global configuration page. This message will be dismissed if Jenkins receives \
   a PING event from repo webhook or if you add the repo to the ignore list in the global configuration.
 unknown.error=Unknown error
+duplicate.events.administrative.monitor.displayname=GitHub Duplicate Events
+duplicate.events.administrative.monitor.description=Warns about duplicate events received from GitHub.
+duplicate.events.administrative.monitor.blurb=Duplicate events were received from GitHub, possibly due to \
+  misconfiguration (e.g., multiple webhooks targeting the same Jenkins controller at the repository or organization \
+  level), potentially causing redundant job executions.

--- a/src/main/resources/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitor/description.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitor/description.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <j:out value="${it.description}"/>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitor/message.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitor/message.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <div class="alert alert-warning">
+        <form method="post" action="${rootURL}/${it.url}/disable" name="${it.id}">
+            <f:submit primary="false" clazz="jenkins-!-destructive-color" name="no" value="${%Dismiss}"/>
+        </form>
+        <j:out value="${it.blurb}"/>
+    </div>
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/admin/GitHubDuplicateEventsMonitorTest.java
@@ -1,0 +1,98 @@
+package org.jenkinsci.plugins.github.admin;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.htmlunit.HttpMethod;
+
+import org.htmlunit.WebRequest;
+import org.jenkinsci.plugins.github.Messages;
+import org.jenkinsci.plugins.github.extension.GHEventsSubscriber;
+import org.jenkinsci.plugins.github.webhook.subscriber.DuplicateEventsSubscriber;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.mockito.Mockito;
+
+public class GitHubDuplicateEventsMonitorTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    private WebClient wc;
+
+    @Before
+    public void setUp() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        wc = j.createWebClient();
+        wc.login("admin", "admin");
+    }
+
+    @Test
+    public void testAdminMonitorDisplaysForDuplicateEvents() throws Exception {
+        try (var mockSubscriber = Mockito.mockStatic(GHEventsSubscriber.class)) {
+            var subscribers = j.jenkins.getExtensionList(GHEventsSubscriber.class);
+            var nonDuplicateSubscribers = subscribers.stream()
+                                                     .filter(e -> !(e instanceof DuplicateEventsSubscriber))
+                                                     .toList();
+            nonDuplicateSubscribers.forEach(subscribers::remove);
+            mockSubscriber.when(GHEventsSubscriber::all).thenReturn(subscribers);
+
+            // to begin with, monitor doesn't show automatically
+            assertMonitorNotDisplayed();
+
+            // normal case: unique events don't cause admin monitor
+            sendGHEvents(wc, "event1");
+            sendGHEvents(wc, "event2");
+            assertMonitorNotDisplayed();
+
+            // duplicate events cause admin monitor
+            sendGHEvents(wc, "event3");
+            sendGHEvents(wc, "event3");
+            assertMonitorDisplayed();
+        }
+    }
+
+    private void sendGHEvents(WebClient wc, String eventGuid) throws IOException {
+        wc.addRequestHeader("Content-Type", "application/json");
+        wc.addRequestHeader("X-GitHub-Delivery", eventGuid);
+        wc.addRequestHeader("X-Github-Event", "push");
+        String url = j.getURL() + "/github-webhook/";
+        String content = """
+                {
+                    "repository":
+                    {
+                        "url": "http://dummy",
+                        "html_url": "http://dummy"
+                    },
+                    "pusher":
+                    {
+                        "name": "dummy",
+                        "email": "dummy@dummy.com"
+                    }
+                }
+            """;
+        var webRequest = new WebRequest(new URL(url), HttpMethod.POST);
+        webRequest.setRequestBody(content);
+        wc.getPage(webRequest).getWebResponse();
+    }
+
+    private void assertMonitorNotDisplayed() throws IOException {
+        String manageUrl = j.getURL() + "/manage";
+        assertThat(
+            wc.getPage(manageUrl).getWebResponse().getContentAsString(),
+            not(containsString(Messages.duplicate_events_administrative_monitor_blurb())));
+    }
+
+    private void assertMonitorDisplayed() throws IOException {
+        String manageUrl = j.getURL() + "/manage";
+        assertThat(
+            wc.getPage(manageUrl).getWebResponse().getContentAsString(),
+            containsString(Messages.duplicate_events_administrative_monitor_blurb()));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DuplicateEventsSubscriberTest.java
+++ b/src/test/java/org/jenkinsci/plugins/github/webhook/subscriber/DuplicateEventsSubscriberTest.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.github.webhook.subscriber;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Set;
+import org.jenkinsci.plugins.github.extension.GHSubscriberEvent;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHEvent;
+import org.mockito.Mockito;
+
+class DuplicateEventsSubscriberTest {
+
+    @Test
+    void shouldReturnEventsWithCountMoreThanOne() {
+        var subscriber = new DuplicateEventsSubscriber();
+        subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
+        subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
+        subscriber.onEvent(new GHSubscriberEvent("2", "origin", GHEvent.PUSH, "payload"));
+        subscriber.onEvent(new GHSubscriberEvent("3", "origin", GHEvent.PUSH, "payload"));
+        assertThat(DuplicateEventsSubscriber.getDuplicateEventCounts(), is(Map.of("1", 2)));
+        assertThat(DuplicateEventsSubscriber.getEventCountsTracker().keySet(), is(Set.of("1", "2", "3")));
+
+        // also notice the `null` guid event is ignored
+        subscriber.onEvent(new GHSubscriberEvent(null, "origin", GHEvent.PUSH, "payload"));
+        assertThat(DuplicateEventsSubscriber.getEventCountsTracker().keySet(), is(Set.of("1", "2", "3")));
+    }
+
+    @Test
+    void shouldCleanupEventsOlderThanTTLMills() {
+        var subscriber = new DuplicateEventsSubscriber();
+        Instant past = OffsetDateTime.parse("2021-01-01T00:00:00Z").toInstant();
+        Instant later = OffsetDateTime.parse("2021-01-01T11:00:00Z").toInstant();
+        try (var mockedInstant = Mockito.mockStatic(Instant.class)) {
+            mockedInstant.when(Instant::now).thenReturn(past);
+            // add two events in `past` instant
+            subscriber.onEvent(new GHSubscriberEvent("1", "origin", GHEvent.PUSH, "payload"));
+            subscriber.onEvent(new GHSubscriberEvent("2", "origin", GHEvent.PUSH, "payload"));
+            assertThat(DuplicateEventsSubscriber.getEventCountsTracker().size(), is(2));
+
+            // add a new event in `later` instant
+            mockedInstant.when(Instant::now).thenReturn(later);
+            subscriber.onEvent(new GHSubscriberEvent("3", "origin", GHEvent.PUSH, "payload"));
+
+            // assert only the new event is present, and old events are cleaned up
+            var tracker = DuplicateEventsSubscriber.getEventCountsTracker();
+            assertThat(tracker.size(), is(1));
+            assertThat(tracker.get("3").count(), is(1));
+            assertThat(tracker.get("3").lastUpdated(), is(later.toEpochMilli()));
+        }
+    }
+}


### PR DESCRIPTION
Demo draft; admin monitor works

|Desc|Screenshot|
|--|--|
|Admin monitor works|![image](https://github.com/user-attachments/assets/549d594e-3e8e-421b-bc09-8105a8b9e7da)|
|Compensatory Periodic cleanup works (in addition to on cleanup upon new event)|<img width="1129" alt="image" src="https://github.com/user-attachments/assets/979e2e91-d771-4eea-a527-3e4b7747b99e" />|

Pending items
- [ ] Type of Github events to watch for (currently I don't understand most of the [GHEvent types](https://github.com/hub4j/github-api/blob/main/src/main/java/org/kohsuke/github/GHEvent.java); currently only put `PUSH` for making the end-to-end GH webhook working
- [ ] The cleanup of old events need to be checked again

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
